### PR TITLE
Disable Turbo on skiplinks

### DIFF
--- a/app/views/shared/_skiplinks.html.erb
+++ b/app/views/shared/_skiplinks.html.erb
@@ -1,4 +1,4 @@
-<div class="fr-skiplinks">
+<div class="fr-skiplinks" data-turbo="false">
   <nav class="fr-container" role="navigation" aria-label="Accès rapide">
     <ul class="fr-skiplinks__list">
       <li>


### PR DESCRIPTION
Turbo doesn't work well with anchor links. 
The issue has been [fixed upstream](https://github.com/hotwired/turbo/pull/298) apparently, but not in this template.